### PR TITLE
[Bug] Add new PR-specific workflow

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,54 @@
+name: Run Unit Tests
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    outputs:
+      conclusion: ${{steps.unit-tests.outputs.conclusion}}
+      coverage: ${{steps.jacoco.outputs.coverage}}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build with Maven
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        continue-on-error: true
+        run: mvn --batch-mode --update-snapshots verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=Matteas-Eden_yet-another-maven-repo
+      - name: test
+        continue-on-error: true
+        id: unit-tests
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: Test Reports
+          path: target/test-results/*.xml
+          reporter: java-junit

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -83,6 +83,7 @@ jobs:
     - name: Create coverage badge
       run: curl https://img.shields.io/static/v1\?label\=coverage\&message\=$COVERAGE%25\&color\=$COVER_COLOUR\&style\=for-the-badge\&link\=https://github.com/Matteas-Eden/yet-another-maven-repo/actions/workflows/run-test.yml > .github/badges/cvrg-badge.svg
     - name: Commit badges
+      continue-on-error: true
       run: |
         git config --local user.name 'github-actions[bot]'
         git config --local user.email 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
# Overview

The purpose of this PR is to add a PR-specific workflow run. Resolves #5 

## The Issue

PRs created from forks of the repository into master do not trigger any checks.

## The Solution

By adding a new workflow file, PRs should now trigger a workflow run and the appropriate checks/

## The Closing Comments

Workflows can potentially be a massive headache.
